### PR TITLE
Revert "fix: Use /usr/share/* for apt/dpkg storage"

### DIFF
--- a/build_files/build
+++ b/build_files/build
@@ -2,13 +2,6 @@
 
 set -ouex pipefail
 
-# Move apt and dpkg folders
-# This is hardcoded in apt so a symlink is necessary
-mv /var/lib/apt /usr/share/apt
-mv /var/lib/dpkg /usr/share/dpkg
-ln -s /usr/share/apt /var/lib/apt
-ln -s /usr/share/dpkg /var/lib/dpkg
-
 # Remove unneeded repositories and update
 rm -f /etc/apt/apt.conf.d/docker-gzip-indexes /etc/apt/apt.conf.d/docker-no-languages
 rm -f /var/log/apt/eipp.log.xz


### PR DESCRIPTION
Reverts frostyard/debian-bootc-core#17

breaks downstream builds.  Maybe look at ordering of the change vs installing bootc.