### PR TITLE
fix: add valid /etc/hosts to base image

### DIFF
--- a/system_files/etc/hosts
+++ b/system_files/etc/hosts
@@ -1,0 +1,4 @@
+# Loopback entries; do not change.
+# For historical reasons, localhost precedes localhost.localdomain:
+127.0.0.1   localhost localhost.localdomain localhost4 localhost4.localdomain4
+::1         localhost localhost.localdomain localhost6 localhost6.localdomain6


### PR DESCRIPTION
This mimics the Fedora CoreOS bootc image approach to ensure /etc/hosts exists with sane defaults and default file perms.