### PR TITLE
chore: disable bls-garbage-collect by default

### DIFF
--- a/build_files/build
+++ b/build_files/build
@@ -48,3 +48,6 @@ chmod 440 /etc/sudoers.d/001-bootc
 
 # Add build information to os-release
 echo "BUILD_ID=\"$BUILD_ID\"" >> /usr/lib/os-release
+
+# remove bls-garbage-collect from /etc/systemd/system/basic.garget.wants
+rm -rf /etc/systemd/system/basic.target.wants/bls-garbage-collect.service

--- a/system_files/usr/lib/systemd/system-preset/02-bls-gc.preset
+++ b/system_files/usr/lib/systemd/system-preset/02-bls-gc.preset
@@ -1,0 +1,2 @@
+# disable bls-garbage-collect.service
+disable bls-garbage-collect.service


### PR DESCRIPTION
Not needed for nbc, so let's leave it but disable.